### PR TITLE
reduce time to interactive

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -115,7 +115,7 @@ export default function App({ jams }) {
   useEffect(() => {
     setTimeout(() => {
       isMounted.current = true
-    }, 2000)
+    }, 1000)
   }, [])
   //to do: if jams length is less than 100 and order/orderby changes,
     //sort the jams client side instead of fetching them


### PR DESCRIPTION
to reduce time to interactive, reduced setTimeout delay to 1s from 2 to set isMounted=true. the purpose is to block the logic in the useEffect that fetches new versions when filter changes from running on mount