### PR TITLE
Shallow routing for searches

### DIFF
--- a/components/AddIdea.js
+++ b/components/AddIdea.js
@@ -101,7 +101,7 @@ export default function AddIdea({ user, profile, setIdeas }) {
 
   async function insertIdea() {
     let ideaToAdd = {
-      user_name: profile.name,
+      user_name: profile?.name || 'Anonymous',
       idea_body: idea,
       tag_idea: ideaType === "tag",
       artist_idea: ideaType === "artist",
@@ -132,11 +132,11 @@ export default function AddIdea({ user, profile, setIdeas }) {
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>Add Suggestion</DialogTitle>
         <DialogContent>
-          {!user && (
+          {/* {!user && (
             <Alert severity="warning" sx={{ mb: "1em" }}>
               Please log in to add a suggestion - thank you!
             </Alert>
-          )}
+          )} */}
           <FormControl sx={{ minWidth: 120, mx: "0.25em", my: "1em" }}>
             <InputLabel id="idea-type">Type</InputLabel>
             <Select
@@ -185,7 +185,7 @@ export default function AddIdea({ user, profile, setIdeas }) {
           {!success && (
             <Button
               onClick={handleSubmit}
-              disabled={loading || !user || !profile || !idea || !ideaType}
+              disabled={loading || !idea || !ideaType}
               sx={{ textTransform: "none" }}
             >
               Add suggestion

--- a/components/AddVersion.js
+++ b/components/AddVersion.js
@@ -132,10 +132,6 @@ export default function AddVersion({
 		}
 	}, [date, song, jams]);
 
-	useEffect(() => {
-		console.log('jam', jam);
-	}, [jam]);
-
 	const handleClickOpen = () => {
 		setOpen(true);
 	};
@@ -157,18 +153,19 @@ export default function AddVersion({
 	};
 
 	useEffect(() => {
-		setDate(null);
-		setLocation(null);
-		setSong(null);
-		setShows(null);
-		setAllShows(null);
-		setSongErrorText(null);
+    if (open) {
+      setDate(null);
+      setLocation(null);
+      setSong(null);
+      setShows(null);
+      setAllShows(null);
+      setSongErrorText(null);
+    }
 	}, [artist]);
 
 	//when date changes
 	//fetch setlist
 	useEffect(() => {
-		console.log('date', date);
 		//make sure the date is from this millenium or the previous one before fetching versions from that date
 		if (date && (date.charAt(0) === '1' || date.charAt(0) === '2') && open) {
 			const data = JSON.stringify({

--- a/components/AppBar.js
+++ b/components/AppBar.js
@@ -9,6 +9,7 @@ import Image from 'next/image';
 import { useUser, useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
+import Link from 'next/link';
 
 export default function TopBar({
 	showButton,
@@ -20,7 +21,6 @@ export default function TopBar({
 }) {
 
 	const handleLogout = async () => {
-		console.log('clicked logout');
 		const { error } = await supabase.auth.signOut();
 		if (error) {
 			console.error(error);
@@ -42,6 +42,7 @@ export default function TopBar({
 						direction='row'
 						sx={{ flexGrow: 1 }}
 					>
+            <Link href='/'>
 						<Image
 							alt='Nice Jammin Logo'
 							src='/icon-circle.png'
@@ -49,9 +50,8 @@ export default function TopBar({
 							priority
 							width={45}
 							height={45}
-							component='a'
-							href='/'
 						/>
+            </Link>
 						<Typography
 							variant='h6'
 							noWrap

--- a/components/ArtistPicker.js
+++ b/components/ArtistPicker.js
@@ -60,8 +60,8 @@ export default function ArtistPicker({ artist, setArtist, size, my }) {
   };
 
   return (
-    <Box my={my ? my : '0.25em'}>
-      <FormControl sx={{ minWidth: 180, mx:'0.25em' }} size={size ? size : 'small' }>
+    <Box my={my ? my : '0.4em'}>
+      <FormControl sx={{ minWidth: 180, mx:'0.5em' }} size={size ? size : 'small' }>
         <InputLabel id="artist-select">Band</InputLabel>
         <Select
           labelId="artist-select"

--- a/components/DateFilter.js
+++ b/components/DateFilter.js
@@ -1,41 +1,58 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 
-export default function DateFilter({ before, beforeDate, setBeforeDate, afterDate, setAfterDate }) {
-  const [dates, setDates] = useState([1965])
+export default function DateFilter({
+	before,
+	beforeDate,
+	setBeforeDate,
+	afterDate,
+	setAfterDate,
+}) {
+	const [dates, setDates] = useState([1965]);
 
-  useEffect(() => {
-    let fullDates = []
-    let currentYear = new Date().getFullYear()
-    for (var i = currentYear; i > 1964; i--) {
-      fullDates.push(i)
-    } setDates(fullDates)
-  }, [])
+	useEffect(() => {
+		let fullDates = [];
+		let currentYear = new Date().getFullYear();
+		for (var i = currentYear; i > 1959; i--) {
+			fullDates.push(i);
+		}
+		setDates(fullDates);
+	}, []);
 
-  function handleChange(event) {
-    let newDate = event.target.value
-    before ? setBeforeDate(newDate) : setAfterDate(newDate)
-  }
+	function handleChange(event) {
+		let newDate = event.target.value;
+		before ? setBeforeDate(newDate) : setAfterDate(newDate);
+	}
 
-  return (
-    <>
-    <FormControl sx={{ minWidth: 120,  m:'0.4em' }} size="small">
-    <InputLabel id={ before ? "before-date-select" : "after-date-select"}>{before ? 'Before' : 'After'}</InputLabel>
-    <Select
-      labelId={ before ? "before-date-select" : "after-date-select"}
-      value={before ? beforeDate : afterDate}
-      label={before ? 'Jams Before' : 'Jams After'}
-      onChange={handleChange}
-      // sx={{ bgcolor: 'primary.main' }}
-      >
-      {dates.map((date) => (
-        <MenuItem key={date} value={date}>{date} or {before ? 'before' : 'after'}</MenuItem>
-        ))}
-    </Select>
-  </FormControl>
-        </>
-  )
+	return (
+		<>
+			<FormControl
+				sx={{ minWidth: 120, m: '0.4em' }}
+				size='small'
+			>
+				<InputLabel id={before ? 'before-date-select' : 'after-date-select'}>
+					{before ? 'Before' : 'After'}
+				</InputLabel>
+				<Select
+					labelId={before ? 'before-date-select' : 'after-date-select'}
+					value={before ? beforeDate : afterDate}
+					label={before ? 'Jams Before' : 'Jams After'}
+					onChange={handleChange}
+					// sx={{ bgcolor: 'primary.main' }}
+				>
+					{dates.map((date) => (
+						<MenuItem
+							key={date}
+							value={date}
+						>
+							{date} or {before ? 'before' : 'after'}
+						</MenuItem>
+					))}
+				</Select>
+			</FormControl>
+		</>
+	);
 }

--- a/components/DateFilter.js
+++ b/components/DateFilter.js
@@ -22,7 +22,7 @@ export default function DateFilter({ before, beforeDate, setBeforeDate, afterDat
 
   return (
     <>
-    <FormControl sx={{ minWidth: 120,  m:'0.25em' }} size="small">
+    <FormControl sx={{ minWidth: 120,  m:'0.4em' }} size="small">
     <InputLabel id={ before ? "before-date-select" : "after-date-select"}>{before ? 'Before' : 'After'}</InputLabel>
     <Select
       labelId={ before ? "before-date-select" : "after-date-select"}

--- a/components/DateFilter.js
+++ b/components/DateFilter.js
@@ -30,7 +30,7 @@ export default function DateFilter({
 	return (
 		<>
 			<FormControl
-				sx={{ minWidth: 120, m: '0.4em' }}
+				sx={{ minWidth: 180, m: '0.4em' }}
 				size='small'
 			>
 				<InputLabel id={before ? 'before-date-select' : 'after-date-select'}>

--- a/components/DatePicker.js
+++ b/components/DatePicker.js
@@ -24,7 +24,7 @@ export default function DatePicker({ setDate, my, date }) {
   })
 
   return (
-    <Box my={my ? my : '0.25em'} sx={{ mx:'0.25em' }}>
+    <Box my={my ? my : '0.5em'} sx={{ mx:'0.5em' }}>
       <LocalizationProvider dateAdapter={AdapterDateFns}>
           <MobileDatePicker
             label="Date"

--- a/components/FilterBar.js
+++ b/components/FilterBar.js
@@ -50,9 +50,9 @@ export default function FilterBar({
 				<Typography
 					textAlign='center'
 					fontSize={20}
-					sx={{ mt: '1em' }}
+					sx={{ mt: '1em', mx: '1em' }}
 				>
-					1. Choose your filters:
+					1. Choose the sounds you want to hear:
 				</Typography>
 				<Box
 					sx={{
@@ -72,16 +72,6 @@ export default function FilterBar({
 					<TagPicker
 						tagsSelected={tagsSelected}
 						setTagsSelected={setTagsSelected}
-					/>
-					<ArtistPicker
-						setArtist={setArtist}
-						artist={artist}
-					/>
-					<Sorter
-						orderBy={orderBy}
-						setOrderBy={setOrderBy}
-						setOrder={setOrder}
-						order={order}
 					/>
 				</Box>
 				<Typography
@@ -112,6 +102,16 @@ export default function FilterBar({
 							p: '0.3em',
 						}}
 					>
+						<Sorter
+							orderBy={orderBy}
+							setOrderBy={setOrderBy}
+							setOrder={setOrder}
+							order={order}
+						/>
+						<ArtistPicker
+							setArtist={setArtist}
+							artist={artist}
+						/>
 						<SongPicker
 							songs={songs}
 							setSong={setSong}
@@ -143,15 +143,23 @@ export default function FilterBar({
 					</Box>
 				)}
 				{jams && (
-					<Typography
-						textAlign='center'
-						fontSize='20px'
-						m='1em'
-					>
-						2. Click a row to listen or rate
-						<br />
-						❤️
-					</Typography>
+					<>
+						<Typography
+							textAlign='center'
+							fontSize='20px'
+							m='.5em'
+						>
+							2. Click a row
+						</Typography>
+						<Typography
+            textAlign='center'
+            fontSize='20px'
+            m='.5em'>
+							3. Listen, comment, and be merry!
+							<br />
+							❤️
+						</Typography>
+					</>
 				)}
 			</Box>
 		</Box>

--- a/components/FilterBar.js
+++ b/components/FilterBar.js
@@ -25,6 +25,7 @@ export default function FilterBar({
 	song,
 	setSong,
 	songs,
+	order,
 	orderBy,
 	setOrderBy,
 	setOrder,
@@ -56,11 +57,11 @@ export default function FilterBar({
 				<Box
 					sx={{
 						display: 'flex',
-            flexDirection: 'column',
+						flexDirection: 'column',
 						flexWrap: 'wrap',
 						alignItems: 'center',
 						mx: 'auto',
-						mt: '0.1em',
+						mt: '0.5em',
 						justifyContent: 'center',
 						bgcolor: 'white',
 						borderRadius: '0.25em',
@@ -76,18 +77,12 @@ export default function FilterBar({
 						setArtist={setArtist}
 						artist={artist}
 					/>
-					<SongPicker
-						songs={songs}
-						setSong={setSong}
-						song={song}
-						size={'small'}
-						artist={artist}
+					<Sorter
+						orderBy={orderBy}
+						setOrderBy={setOrderBy}
+						setOrder={setOrder}
+						order={order}
 					/>
-          <Sorter
-							orderBy={orderBy}
-							setOrderBy={setOrderBy}
-							setOrder={setOrder}
-						/>
 				</Box>
 				<Typography
 					textAlign={'center'}
@@ -117,6 +112,13 @@ export default function FilterBar({
 							p: '0.3em',
 						}}
 					>
+						<SongPicker
+							songs={songs}
+							setSong={setSong}
+							song={song}
+							size={'small'}
+							artist={artist}
+						/>
 						<DateFilter
 							before={false}
 							afterDate={afterDate}

--- a/components/FilterBar.js
+++ b/components/FilterBar.js
@@ -9,8 +9,7 @@ import Sorter from './Sorter';
 import Checkbox from '@mui/material/Checkbox';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import SettingsIcon from '@mui/icons-material/Settings';
-import { color } from '@mui/system';
+import JamLimitPicker from './JamLimitPicker';
 
 export default function FilterBar({
 	setDates,
@@ -31,9 +30,22 @@ export default function FilterBar({
 	setOrder,
 	showRatings,
 	handleShowRatingsChange,
+  showMoreFilters,
+  setShowMoreFilters,
 	jams,
+  showListenable,
+  setShowListenable,
+  limit,
+  setLimit
 }) {
-	const [showMore, setShowMore] = useState(false);
+
+  function handleListenableChange(e) {
+    setShowListenable(e.target.checked);
+  }
+
+  function handleShowMoreChange() {
+    setShowMoreFilters(!showMoreFilters);
+  }
 
 	return (
 		<Box sx={{ mx: '0.5em', mt: '1em' }}>
@@ -83,11 +95,11 @@ export default function FilterBar({
 							color: 'black',
 						},
 					}}
-					onClick={() => setShowMore(!showMore)}
+					onClick={handleShowMoreChange}
 				>
-					{showMore ? '✌️ Less' : '⚙️ More'}
+					{showMoreFilters ? '✌️ Less' : '⚙️ More'}
 				</Typography>
-				{showMore && (
+				{showMoreFilters && (
 					<Box
 						sx={{
 							display: 'flex',
@@ -141,6 +153,18 @@ export default function FilterBar({
 								label='Show ratings'
 							/>
 						</FormControl>
+            <FormControl sx={{ display: 'flex', alignItems: 'center' }}>
+							<FormControlLabel
+								control={
+									<Checkbox
+										checked={showListenable}
+										onChange={handleListenableChange}
+									/>
+								}
+								label='Only show jams with listenable links'
+							/>
+						</FormControl>
+            <JamLimitPicker limit={limit} setLimit={setLimit} />
 					</Box>
 				)}
 				{jams && (

--- a/components/FilterBar.js
+++ b/components/FilterBar.js
@@ -91,6 +91,7 @@ export default function FilterBar({
 					<Box
 						sx={{
 							display: 'flex',
+              flexDirection: 'column',
 							flexWrap: 'wrap',
 							alignItems: 'center',
 							mx: 'auto',

--- a/components/FilterBar.js
+++ b/components/FilterBar.js
@@ -115,12 +115,6 @@ export default function FilterBar({
 							p: '0.3em',
 						}}
 					>
-						<Sorter
-							orderBy={orderBy}
-							setOrderBy={setOrderBy}
-							setOrder={setOrder}
-							order={order}
-						/>
 						<ArtistPicker
 							setArtist={setArtist}
 							artist={artist}
@@ -142,6 +136,13 @@ export default function FilterBar({
 							beforeDate={beforeDate}
 							setBeforeDate={setBeforeDate}
 						/>
+            <JamLimitPicker limit={limit} setLimit={setLimit} />
+            <Sorter
+							orderBy={orderBy}
+							setOrderBy={setOrderBy}
+							setOrder={setOrder}
+							order={order}
+						/>
 						<FormControl sx={{ display: 'flex', alignItems: 'center' }}>
 							<FormControlLabel
 								control={
@@ -150,7 +151,7 @@ export default function FilterBar({
 										onChange={handleShowRatingsChange}
 									/>
 								}
-								label='Show ratings'
+								label='Show ratings in table'
 							/>
 						</FormControl>
             <FormControl sx={{ display: 'flex', alignItems: 'center' }}>
@@ -161,10 +162,10 @@ export default function FilterBar({
 										onChange={handleListenableChange}
 									/>
 								}
-								label='Only show jams with listenable links'
+								label='Only show jams with links'
 							/>
 						</FormControl>
-            <JamLimitPicker limit={limit} setLimit={setLimit} />
+            
 					</Box>
 				)}
 				{jams && (

--- a/components/FilterChip.js
+++ b/components/FilterChip.js
@@ -14,6 +14,7 @@ const tags = {
   'fast': 'Fast',
   'funky': 'Funky',
   'groovy': 'Groovy',
+  'grimy': 'Grimy',
   'guest': 'Guest',
   'happy': 'Happy',
   'heavy': 'Heavy',

--- a/components/JamLimitPicker.js
+++ b/components/JamLimitPicker.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
+import Box from '@mui/material/Box'
+
+let options = [
+  {label: 20, value: 20},
+  {label: 50, value: 50},
+  {label: 100, value: 100},
+  {label: 200, value: 200},
+  {label: 'All', value: null},
+]
+
+export default function JamLimitPicker({ limit, setLimit }) {
+
+  const handleChange = (event) => {
+    setLimit(event.target.value);
+  };
+
+  return (
+    <Box my='0.4em'>
+      <FormControl sx={{ minWidth: 180, mx:'0.5em' }} size= 'small'>
+        <InputLabel id="jam-limit-select">How many to display</InputLabel>
+        <Select
+          labelId="jam-limit-select"
+          value={limit ?? 20}
+          label="How many to display"
+          onChange={handleChange}
+          >
+          {options.map((option, index) => (
+            <MenuItem key={index} value={option.value}>{option.label}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+}

--- a/components/JamsTableCollapsible.js
+++ b/components/JamsTableCollapsible.js
@@ -427,11 +427,11 @@ export default function CollapsibleTable({
 	songs,
 	showRatings,
 }) {
-	const [orderedSongs, setOrderedSongs] = useState(null);
-	const [jamsFetched, setJamsFetched] = useState(false);
-	const [songsFetched, setSongsFetched] = useState(false);
-	const [fetchingJams, setFetchingJams] = useState(false);
-	const [fetchingSongs, setFetchingSongs] = useState(false);
+	// const [orderedSongs, setOrderedSongs] = useState(null);
+	// const [jamsFetched, setJamsFetched] = useState(false);
+	// const [songsFetched, setSongsFetched] = useState(false);
+	// const [fetchingJams, setFetchingJams] = useState(false);
+	// const [fetchingSongs, setFetchingSongs] = useState(false);
 
 	const handleRequestSort = (event, property) => {
 		if (property === 'avg_rating' && orderBy !== 'avg_rating') {

--- a/components/JamsTableCollapsible.js
+++ b/components/JamsTableCollapsible.js
@@ -114,7 +114,7 @@ function JamsTableHead({ order, orderBy, onRequestSort, showRatings }) {
 									{orderBy === headCell.id ? (
 										<Box
 											component='span'
-											// sx={visuallyHidden}
+											sx={visuallyHidden}
 										>
 											{order === 'desc'
 												? 'sorted descending'
@@ -147,7 +147,7 @@ function JamsTableHead({ order, orderBy, onRequestSort, showRatings }) {
 									{orderBy === headCell.id ? (
 										<Box
 											component='span'
-											// sx={visuallyHidden}
+											sx={visuallyHidden}
 										>
 											{order === 'desc'
 												? 'sorted descending'
@@ -442,18 +442,6 @@ export default function CollapsibleTable({
 		}
 		setOrderBy(property);
 	};
-
-	useEffect(() => {
-		if (!songsFetched && !fetchingSongs) {
-			setFetchingSongs(true);
-			const getSongs = async () => {
-				let songs = await fetchSongs();
-				setSongsFetched(true);
-				setSongs(songs);
-			};
-			getSongs();
-		}
-	});
 
 	// function descendingComparator(a, b, orderBy) {
 	//   if (b[orderBy] < a[orderBy]) {

--- a/components/RateVersion.js
+++ b/components/RateVersion.js
@@ -16,6 +16,7 @@ import InputLabel from '@mui/material/InputLabel';
 import FormControl from '@mui/material/FormControl';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Link from 'next/link';
 
 export default function RateVersion({
 	song,
@@ -256,11 +257,11 @@ export default function RateVersion({
 		let index = songs.findIndex((item) => {
 			return item.song === song;
 		});
-    if (index !==-1) {
-      setSongSubmitter(songs[index].submitter_name);
-    } else {
-      setSongSubmitter(null)
-    }
+		if (index !== -1) {
+			setSongSubmitter(songs[index].submitter_name);
+		} else {
+			setSongSubmitter(null);
+		}
 	}, []);
 
 	const handleSubmit = async () => {
@@ -353,7 +354,9 @@ export default function RateVersion({
 					setButtonText('Update');
 				}
 			};
-			checkRated();
+      if (profile) {
+        checkRated();
+      }
 		}
 	}, [user, profile, jam, open]);
 
@@ -493,77 +496,81 @@ export default function RateVersion({
 							severity='warning'
 							sx={{ mb: '1em' }}
 						>
-							Please log in to rate this jam - thank you!
+							Please <Link href='/login'>log in</Link> to rate this jam - thank you!
 						</Alert>
 					)}
-					<Box sx={{ minWidth: '120px', mx: '0.25em', my: '1em' }}>
-						<FormControl>
-							<InputLabel id='rating-select-label'>Rating</InputLabel>
-							<Select
-								sx={{ minWidth: '120px' }}
-								size='normal'
-								labelId='rating-select-label'
-								id='rating-select'
-								value={rating}
-								label='Rating'
-								onChange={handleRatingChange}
+					{user && (
+						<>
+							<Box sx={{ minWidth: '120px', mx: '0.25em', my: '1em' }}>
+								<FormControl>
+									<InputLabel id='rating-select-label'>Rating</InputLabel>
+									<Select
+										sx={{ minWidth: '120px' }}
+										size='normal'
+										labelId='rating-select-label'
+										id='rating-select'
+										value={rating}
+										label='Rating'
+										onChange={handleRatingChange}
+									>
+										<MenuItem value={10}>10</MenuItem>
+										<MenuItem value={9}>9</MenuItem>
+										<MenuItem value={8}>8</MenuItem>
+										<MenuItem value={7}>7</MenuItem>
+										<MenuItem value={6}>6</MenuItem>
+										<MenuItem value={5}>5</MenuItem>
+										<MenuItem value={4}>4</MenuItem>
+										<MenuItem value={3}>3</MenuItem>
+										<MenuItem value={2}>2</MenuItem>
+										<MenuItem value={1}>1</MenuItem>
+									</Select>
+								</FormControl>
+								{ratingErrorText && (
+									<Alert
+										severity='error'
+										sx={{ mb: '1em' }}
+									>
+										{ratingErrorText}
+									</Alert>
+								)}
+							</Box>
+							<Typography
+								mx='0.25em'
+								mt='1em'
 							>
-								<MenuItem value={10}>10</MenuItem>
-								<MenuItem value={9}>9</MenuItem>
-								<MenuItem value={8}>8</MenuItem>
-								<MenuItem value={7}>7</MenuItem>
-								<MenuItem value={6}>6</MenuItem>
-								<MenuItem value={5}>5</MenuItem>
-								<MenuItem value={4}>4</MenuItem>
-								<MenuItem value={3}>3</MenuItem>
-								<MenuItem value={2}>2</MenuItem>
-								<MenuItem value={1}>1</MenuItem>
-							</Select>
-						</FormControl>
-						{ratingErrorText && (
-							<Alert
-								severity='error'
-								sx={{ mb: '1em' }}
-							>
-								{ratingErrorText}
-							</Alert>
-						)}
-					</Box>
-					<Typography
-						mx='0.25em'
-						mt='1em'
-					>
-						Optional:
-					</Typography>
-					<TextField
-						autoFocus
-						sx={{ mx: '0.25em', mb: '1em' }}
-						margin='dense'
-						id='comment'
-						label='Comments'
-						value={comment}
-						type='text'
-						fullWidth
-						variant='standard'
-						multiline
-						onChange={handleCommentChange}
-					/>
-					<TagPicker
-						tagsSelected={newTags}
-						setTagsSelected={setNewTags}
-						size={'normal'}
-					/>
-					{tags && <Typography>Current Sounds: {tags}</Typography>}
-					{tagsToAddText && (
-						<Typography>Sounds to Add: {tagsToAddText}</Typography>
-					)}
-					{successAlertText && (
-						<Alert
-							severity='success'
-							sx={{ my: '1em' }}
-						>
-							{successAlertText}
-						</Alert>
+								Optional:
+							</Typography>
+							<TextField
+								autoFocus
+								sx={{ mx: '0.25em', mb: '1em' }}
+								margin='dense'
+								id='comment'
+								label='Comments'
+								value={comment}
+								type='text'
+								fullWidth
+								variant='standard'
+								multiline
+								onChange={handleCommentChange}
+							/>
+							<TagPicker
+								tagsSelected={newTags}
+								setTagsSelected={setNewTags}
+								size={'normal'}
+							/>
+							{tags && <Typography>Current Sounds: {tags}</Typography>}
+							{tagsToAddText && (
+								<Typography>Sounds to Add: {tagsToAddText}</Typography>
+							)}
+							{successAlertText && (
+								<Alert
+									severity='success'
+									sx={{ my: '1em' }}
+								>
+									{successAlertText}
+								</Alert>
+							)}
+						</>
 					)}
 				</DialogContent>
 				<DialogActions>

--- a/components/ShowPicker.js
+++ b/components/ShowPicker.js
@@ -15,7 +15,7 @@ export default function ShowPicker({ show, shows, setShow, setDate, setLocation,
   };
 
   return (
-    <Box my="1em">
+    <Box my=".4em">
       <FormControl sx={{ minWidth: 120, mx:'0.25em' }}>
         <InputLabel id="show-select">Show</InputLabel>
         <Select

--- a/components/SongPicker.js
+++ b/components/SongPicker.js
@@ -80,7 +80,7 @@ export default function SongPicker({ artist, songs, song, setSong, setlist, wide
 
   if (!setlist || setlist.length === 0) {
     return (
-      <Box mx={mx ? mx : '0.25em'}  my={my ? my : '0.25em'} sx={{ 
+      <Box mx={mx ? mx : '0.5em'}  my={my ? my : '0.4em'} sx={{ 
         minWidth: '180px',
         maxWidth: '240px',
       }}>

--- a/components/Sorter.js
+++ b/components/Sorter.js
@@ -3,88 +3,123 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
-import Box from '@mui/material/Box'
+import Box from '@mui/material/Box';
 
 let sortOptions = [
-    'Newest',
-    'Oldest',
-    'Rating',
-    'Number of Ratings',
-    'Recently Added',
-    'Song A-Z',
-    'Artist A-Z',
-    'Song Z-A',
-    'Artist Z-A',
-]
+	'Newest',
+	'Oldest',
+	'Rating',
+	'Number of Ratings',
+	'Recently Added',
+	'Song A-Z',
+	'Artist A-Z',
+	'Song Z-A',
+	'Artist Z-A',
+];
 
-export default function Sorter({ orderBy, setOrderBy, setOrder, size, my }) {
+export default function Sorter({ orderBy, order, setOrderBy, setOrder, size, my }) {
+	useEffect(() => {
+		console.log('orderBy', orderBy);
+	});
 
-  const [label, setLabel] = useState('Recently Added')
+	let label;
+	switch (orderBy) {
+		case 'date':
+			if (order === 'asc') label = 'Oldest';
+			else label = 'Newest';
+			break;
+		case 'avg_rating':
+			label = 'Rating';
+			break;
+		case 'num_ratings':
+			label = 'Number of Ratings';
+			break;
+		case 'song_name':
+			if (order === 'asc') label = 'Song A-Z';
+			else label = 'Song Z-A';
+			break;
+		case 'artist':
+			if (order === 'asc') label = 'Artist A-Z';
+			else label = 'Artist Z-A';
+			break;
+		case 'id':
+			label = 'Recently Added';
+			break;
+	}
 
-  const handleChange = (event) => {
-      setLabel(event.target.value);
-      switch (event.target.value) {
-        case 'Newest':
-          setOrderBy('date')
-          setOrder('desc')
-          break
-        case 'Oldest':
-          setOrderBy('date')
-          setOrder('asc')
-          break;
-        case 'Rating':
-          setOrderBy('avg_rating')
-          setOrder('desc')
-          break;
-        case 'Number of Ratings':
-          setOrderBy('num_ratings')
-          setOrder('desc')
-          break;
-        case 'Song A-Z':
-          setOrderBy('song_name')
-          setOrder('asc')
-          break;
-        case 'Artist A-Z':
-          setOrderBy('artist')
-          setOrder('asc')
-          break;
-        case 'Song Z-A':
-          setOrderBy('song_name')
-          setOrder('desc')
-          break;
-        case 'Artist Z-A':
-          setOrderBy('artist')
-          setOrder('desc')
-          break;
-        case 'Recently Added':
-          setOrderBy('id')
-          setOrder('desc')
-          break;
-        }
-  };
+	const handleChange = (event) => {
+		label = event.target.value;
+		switch (event.target.value) {
+			case 'Newest':
+				setOrderBy('date');
+				setOrder('desc');
+				break;
+			case 'Oldest':
+				setOrderBy('date');
+				setOrder('asc');
+				break;
+			case 'Rating':
+				setOrderBy('avg_rating');
+				setOrder('desc');
+				break;
+			case 'Number of Ratings':
+				setOrderBy('num_ratings');
+				setOrder('desc');
+				break;
+			case 'Song A-Z':
+				setOrderBy('song_name');
+				setOrder('asc');
+				break;
+			case 'Artist A-Z':
+				setOrderBy('artist');
+				setOrder('asc');
+				break;
+			case 'Song Z-A':
+				setOrderBy('song_name');
+				setOrder('desc');
+				break;
+			case 'Artist Z-A':
+				setOrderBy('artist');
+				setOrder('desc');
+				break;
+			case 'Recently Added':
+				setOrderBy('id');
+				setOrder('desc');
+				break;
+		}
+	};
 
-  return (
-    <div>
-      <Box sx={{
-        display: 'flex',
-        justifyContent: 'center',
-        my: '0.25em'
-
-      }}>
-        <FormControl sx={{ minWidth: 180, mx:'0.25em' }} size={size ? size : 'small' }>
-          <InputLabel id="sorter">Sort by</InputLabel>
-          <Select
-            labelId="sorter"
-            value={label}
-            label="Sort by"
-            onChange={handleChange}
-            >
-            {sortOptions.map((sort) => (
-              <MenuItem key={sort} value={sort}>{sort}</MenuItem>
-              ))}
-          </Select>
-        </FormControl>
-      </Box>
-    </div>
-  );
+	return (
+		<div>
+			<Box
+				sx={{
+					display: 'flex',
+					justifyContent: 'center',
+					my: '0.5em',
+				}}
+			>
+				<FormControl
+					sx={{ minWidth: 180, mx: '0.5em' }}
+					size={size ? size : 'small'}
+				>
+					<InputLabel id='sorter'>Sort by</InputLabel>
+					<Select
+						labelId='sorter'
+						value={label}
+						label='Sort by'
+						onChange={handleChange}
+					>
+						{sortOptions.map((sort) => (
+							<MenuItem
+								key={sort}
+								value={sort}
+							>
+								{sort}
+							</MenuItem>
+						))}
+					</Select>
+				</FormControl>
+			</Box>
+		</div>
+	);
 }

--- a/components/Sorter.js
+++ b/components/Sorter.js
@@ -90,12 +90,12 @@ export default function Sorter({ orderBy, order, setOrderBy, setOrder, size, my 
 	};
 
 	return (
-		<div>
+		<>
 			<Box
 				sx={{
 					display: 'flex',
 					justifyContent: 'center',
-					my: '0.5em',
+					my: '0.3em',
 				}}
 			>
 				<FormControl
@@ -120,6 +120,6 @@ export default function Sorter({ orderBy, order, setOrderBy, setOrder, size, my 
 					</Select>
 				</FormControl>
 			</Box>
-		</div>
+		</>
 	);
 }

--- a/components/TagPicker.js
+++ b/components/TagPicker.js
@@ -112,19 +112,20 @@ const tags = [
 ];
 
 export default function TagPicker({ tagsSelected, setTagsSelected, size, mx, my }) {
+  const [prelimTagsSelected, setPrelimTagsSelected] = useState(tagsSelected);
 
   const handleChange = (event) => {
     const {
       target: { value },
     } = event;
-    setTagsSelected(
+    setPrelimTagsSelected(
       // On autofill we get a stringified value.
       typeof value === 'string' ? value.split(',') : value,
     );
   };
 
   return (
-    <Box mx={mx ? mx : '0.25em'} my={my ? my : '0.25em'} minWidth="120px">
+    <Box mx={mx ? mx : '0.5em'} my={my ? my : '0.5em'} minWidth="120px">
       <FormControl sx={{ minWidth: 180 }} size={size ? size : "small"}>
         <InputLabel id="tag-filter-select-label">Sounds</InputLabel>
         <Select
@@ -132,15 +133,16 @@ export default function TagPicker({ tagsSelected, setTagsSelected, size, mx, my 
           id="tag-filter-select-checkbox"
           multiple
           // sx={{ bgcolor: 'primary.main' }}
-          value={tagsSelected}
+          value={prelimTagsSelected}
           onChange={handleChange}
           input={<OutlinedInput label="Sounds" />}
-          renderValue={() => (`${tagsSelected.length} selected`)}
+          renderValue={() => (`${prelimTagsSelected.length} selected`)}
           MenuProps={MenuProps}
+          onClose={() => setTagsSelected(prelimTagsSelected)}
         >
           {tags.map((tag) => (
             <MenuItem key={tag.value} value={tag.value}>
-              <Checkbox checked={tagsSelected.indexOf(tag.value) > -1} />
+              <Checkbox checked={prelimTagsSelected.indexOf(tag.value) > -1} />
               <ListItemText primary={tag.label} />
             </MenuItem>
           ))}

--- a/next.config.js
+++ b/next.config.js
@@ -12,10 +12,10 @@ module.exports = withBundleAnalyzer({})
 module.exports = nextConfig
 
 module.exports = {
-  // i18n: {
-  //   locales: ['en'],
-  //   defaultLocale: 'en',
-  // },
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+  },
   serverRuntimeConfig: {
     baseUrls: {
       eggyBaseUrl: 'https://thecarton.net/api/v1',

--- a/pages/api/contributions.ts
+++ b/pages/api/contributions.ts
@@ -40,8 +40,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 				const ratings = ratingsObj.data;
 				const ideas = ideasObj.data;
         const allSongs = allSongsObj.data;
-				console.log('ratings', ratings);
-				console.log('versions', versions);
 				if (ratings) {
 					const versionsUserHasRated = ratings.map(
 						(rating) => rating.version_id
@@ -53,26 +51,20 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 					Promise.all([fetchVersionsRated])
 						.then(([ratedVersions]) => {
 							const versionsRated: Array<any> | null = ratedVersions.data;
-							console.log('ratings', ratings);
-							console.log('versionsRated', versionsRated);
 							if (versionsRated) {
 								const ratingsWithVersions = ratings.map((rating) => {
 									const index: number = versionsRated.findIndex(
 										(version) => version.id === rating.version_id
 									);
-									console.log('index', index);
 									let versionInfo;
 									if (versionsRated && (index || index === 0)) {
 										versionInfo = versionsRated[index];
 									}
-									console.log('versionInfo', versionInfo);
 									return {
 										rating,
 										versionInfo,
 									};
 								});
-								console.log('ratings with versions', ratingsWithVersions);
-								console.log('versions before sending', versions);
 								res.status(200).send({
 									ratings: ratingsWithVersions,
 									songs,
@@ -83,7 +75,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 							}
 						})
 						.catch((error) => {
-							console.log(error);
+							console.error(error);
 							res
 								.status(500)
 								.send({ message: 'fetch rated versions rejected' });
@@ -99,7 +91,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 				}
 			})
 			.catch((error) => {
-				console.log(error);
+				console.error(error);
 				res
 					.status(500)
 					.send({ message: 'one of the initial promises rejected' });

--- a/pages/api/ideas.ts
+++ b/pages/api/ideas.ts
@@ -6,7 +6,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     const { data, error } = await supabase
       .from('ideas')
       .select('*')
-    console.log('ideas', data)
     if (error) {
       console.error('error getting ideas', error)
     } else {

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -9,7 +9,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       .from('profiles')
       .select('*')
       .eq('id', id)
-    console.log('profiles', data)
     if (error) {
       console.error('error getting ideas', error)
     } else {

--- a/pages/api/versions.js
+++ b/pages/api/versions.js
@@ -8,7 +8,7 @@ export default async function handler(req, res) {
 	const beforeDate = body.beforeDate;
 	const afterDate = body.afterDate;
 	const tags = body.tags;
-	const orderBy = body.orderBy ?? 'avg_rating';
+	const orderBy = body.orderBy ?? 'id';
 	const asc = body.order === 'asc' ? true : false;
 	const fetchFullJams = body.fetchFullJams;
 	const limit = body.limit ?? 20;
@@ -62,7 +62,6 @@ export default async function handler(req, res) {
 					artist: artist,
 					date: date,
 				});
-			console.log('versions', data);
 			if (error) {
 				console.error(error);
 				res.status(500).send(error);

--- a/pages/index.js
+++ b/pages/index.js
@@ -54,8 +54,8 @@ export default function App({
 	initialOrder,
 	initialOrderBy,
 	initialLimit,
-  initialShowMoreFilters,
-  initialShowListenable,
+	initialShowMoreFilters,
+	initialShowListenable,
 }) {
 	// const [currentJams, setCurrentJams] = useState(jams);
 	const [songs, setSongs] = useState(initialSongs);
@@ -77,14 +77,16 @@ export default function App({
 	const router = useRouter();
 	const [showRatings, setShowRatings] = useState(false);
 	const isMounted = useRef(false);
-  const [showMoreFilters, setShowMoreFilters] = useState(initialShowMoreFilters);
-  const [showListenable, setShowListenable] = useState(initialShowListenable);
-  const [limit, setLimit] = useState(initialLimit);
+	const [showMoreFilters, setShowMoreFilters] = useState(
+		initialShowMoreFilters
+	);
+	const [showListenable, setShowListenable] = useState(initialShowListenable);
+	const [limit, setLimit] = useState(initialLimit);
 
 	useEffect(() => {
 		if (isMounted.current) {
-      //check song exists or no song before reloading
-			if ((!song || (song && songExists))) {
+			//check song exists or no song before reloading
+			if (!song || (song && songExists)) {
 				let index = songs.findIndex((item) => {
 					return item.song === song;
 				});
@@ -97,17 +99,17 @@ export default function App({
 					if (afterDate) query.afterDate = afterDate;
 					if (order !== 'desc') query.order = order;
 					if (orderBy !== 'id') query.orderBy = orderBy;
-          query.showMoreFilters = showMoreFilters;
-          query.showListenable = showListenable;
-          query.limit = limit;
+					if (showMoreFilters) query.showMoreFilters = showMoreFilters;
+					if (showListenable) query.showListenable = showListenable;
+					if (limit !== 20) query.limit = limit;
 					const params = new URLSearchParams(query).toString();
 					if (params.length > 0) {
 						router.push(`/?${params}`, null, {
-              scroll: false
-            });
+							scroll: false,
+						});
 					} else {
-            router.push('/');
-          }
+						router.push('/');
+					}
 				}
 			}
 		}
@@ -120,8 +122,8 @@ export default function App({
 		songExists,
 		order,
 		orderBy,
-    showListenable,
-    limit
+		showListenable,
+		limit,
 	]);
 
 	useEffect(() => {
@@ -310,20 +312,20 @@ export default function App({
 					songs={songs}
 					song={song}
 					setSong={setSong}
-          order={order}
+					order={order}
 					orderBy={orderBy}
 					setOrderBy={setOrderBy}
 					setOrder={setOrder}
 					showRatings={showRatings}
 					handleShowRatingsChange={handleShowRatingsChange}
 					jams={jams && jams.length > 0}
-          showMoreFilters={showMoreFilters}
-          setShowMoreFilters={setShowMoreFilters}
-          showListenable={showListenable}
-          setShowListenable={setShowListenable}
-          limit={limit}
-          setLimit={setLimit}
-          />
+					showMoreFilters={showMoreFilters}
+					setShowMoreFilters={setShowMoreFilters}
+					showListenable={showListenable}
+					setShowListenable={setShowListenable}
+					limit={limit}
+					setLimit={setLimit}
+				/>
 				<FilterList
 					artist={artist}
 					setArtist={setArtist}
@@ -389,7 +391,7 @@ export const getServerSideProps = async (ctx) => {
 		data: { session },
 	} = await supabase.auth.getSession();
 	const params = ctx.query;
-  console.log('params', params)
+	console.log('params', params);
 	const artist = params?.artist;
 	const song = params?.song;
 	const sounds = params?.sounds;
@@ -399,8 +401,8 @@ export const getServerSideProps = async (ctx) => {
 	const orderBy = params?.orderBy ?? 'id';
 	const asc = params?.order === 'asc' ? true : false;
 	const limit = params?.limit ?? 20;
-  const showMoreFilters = params?.showMoreFilters === 'true';
-  const showListenable = params?.showListenable === 'true';
+	const showMoreFilters = params?.showMoreFilters === 'true';
+	const showListenable = params?.showListenable === 'true';
 	let jams = supabase.from('versions').select('*');
 	if (artist) {
 		jams = jams.eq('artist', artist);
@@ -421,9 +423,9 @@ export const getServerSideProps = async (ctx) => {
 			jams = jams.eq(tag, true);
 		});
 	}
-  if (showListenable) {
-    jams = jams.not('listen_link', 'is', null);
-  }
+	if (showListenable) {
+		jams = jams.not('listen_link', 'is', null);
+	}
 	jams = jams.order(orderBy, { ascending: asc });
 	if (orderBy === 'avg_rating') {
 		jams = jams.order('num_ratings', { ascending: false });
@@ -479,7 +481,7 @@ export const getServerSideProps = async (ctx) => {
 			initialOrder: asc ? 'asc' : 'desc',
 			initialLimit: limit,
 			initialShowListenable: showListenable,
-      initialShowMoreFilters: showMoreFilters,
+			initialShowMoreFilters: showMoreFilters,
 		},
 	};
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -54,9 +54,10 @@ export default function App({
 	initialOrder,
 	initialOrderBy,
 	initialLimit,
-	initialHasLink,
+  initialShowMoreFilters,
+  initialShowListenable,
 }) {
-	const [currentJams, setCurrentJams] = useState(jams);
+	// const [currentJams, setCurrentJams] = useState(jams);
 	const [songs, setSongs] = useState(initialSongs);
 	const [user, setUser] = useState(initialUser);
 	const [session, setSession] = useState(initialSession);
@@ -76,11 +77,14 @@ export default function App({
 	const router = useRouter();
 	const [showRatings, setShowRatings] = useState(false);
 	const isMounted = useRef(false);
+  const [showMoreFilters, setShowMoreFilters] = useState(initialShowMoreFilters);
+  const [showListenable, setShowListenable] = useState(initialShowListenable);
+  const [limit, setLimit] = useState(initialLimit);
 
 	useEffect(() => {
 		if (isMounted.current) {
-			if ((!song || (song && songExists)) && songs) {
-				//double check song exists - before, when you deleted a char from an existing song, songExists updated after the GET request for versions had been sent
+      //check song exists or no song before reloading
+			if ((!song || (song && songExists))) {
 				let index = songs.findIndex((item) => {
 					return item.song === song;
 				});
@@ -93,8 +97,10 @@ export default function App({
 					if (afterDate) query.afterDate = afterDate;
 					if (order !== 'desc') query.order = order;
 					if (orderBy !== 'id') query.orderBy = orderBy;
+          query.showMoreFilters = showMoreFilters;
+          query.showListenable = showListenable;
+          query.limit = limit;
 					const params = new URLSearchParams(query).toString();
-					console.log('params before push', params);
 					if (params.length > 0) {
 						router.push(`/?${params}`, null, {
               scroll: false
@@ -102,41 +108,6 @@ export default function App({
 					} else {
             router.push('/');
           }
-					// 	const data = JSON.stringify({
-					// 		artist,
-					// 		song,
-					// 		afterDate: afterDate ? afterDate.toString() : null,
-					// 		beforeDate: beforeDate ? beforeDate.toString() : null,
-					// 		tags: tagsSelected,
-					// 		orderBy,
-					// 		order,
-					// 		fetchFullJams: true,
-					// 	});
-					// 	try {
-					// 		fetch('/api/versions', {
-					// 			method: 'POST',
-					// 			body: data,
-					// 		})
-					// 			.then((data) => data.json())
-					// 			.then((versions) => {
-					// 				setCurrentJams(versions);
-					//         let query = {};
-					// 				if (artist) query.artist = artist;
-					// 				if (song) query.song = song;
-					// 				if (tagsSelected.length > 0) query.sounds = tagsSelected;
-					// 				if (beforeDate) query.beforeDate = beforeDate;
-					// 				if (afterDate) query.afterDate = afterDate;
-					// 				if (order !== 'desc') query.order = order;
-					// 				if (orderBy !== 'id') query.orderBy = orderBy;
-					// 				const params = new URLSearchParams(query).toString();
-					// 				console.log(params);
-					//         if (params.length > 0) {
-					//           router.push(`/?${params}`, `/?${params}`, { shallow: true });
-					//         }
-					// 			})
-					// 	} catch (error) {
-					// 		console.error(error);
-					// 	}
 				}
 			}
 		}
@@ -149,25 +120,9 @@ export default function App({
 		songExists,
 		order,
 		orderBy,
+    showListenable,
+    limit
 	]);
-
-  useEffect(() => {
-    console.log('song in uE', song)
-  }, [song])
-
-	// useEffect(() => {
-	// 	let query = {};
-	// 	if (artist) query.artist = artist;
-	// 	if (song) query.song = song;
-	// 	if (tagsSelected.length > 0) query.sounds = tagsSelected;
-	// 	if (beforeDate) query.beforeDate = beforeDate;
-	// 	if (afterDate) query.afterDate = afterDate;
-	// 	if (order !== 'desc') query.order = order;
-	// 	if (orderBy !== 'id') query.orderBy = orderBy;
-	// 	let params = new URLSearchParams(query).toString();
-	// 	console.log(params);
-	// 	router.push(`/?${params}`, undefined, { shallow: true });
-	// }, [artist, song, tagsSelected, beforeDate, afterDate, order, orderBy]);
 
 	useEffect(() => {
 		if (songs) {
@@ -361,8 +316,14 @@ export default function App({
 					setOrder={setOrder}
 					showRatings={showRatings}
 					handleShowRatingsChange={handleShowRatingsChange}
-					jams={currentJams && currentJams.length > 0}
-				/>
+					jams={jams && jams.length > 0}
+          showMoreFilters={showMoreFilters}
+          setShowMoreFilters={setShowMoreFilters}
+          showListenable={showListenable}
+          setShowListenable={setShowListenable}
+          limit={limit}
+          setLimit={setLimit}
+          />
 				<FilterList
 					artist={artist}
 					setArtist={setArtist}
@@ -374,18 +335,18 @@ export default function App({
 					setAfterDate={setAfterDate}
 					song={song}
 					setSong={setSong}
-					jams={currentJams.length > 0}
+					jams={jams && jams.length > 0}
 				/>
 				<Suspense fallback={<p>Loading....</p>}>
 					<DynamicJamsTable
-						jams={currentJams}
+						jams={jams}
 						order={order}
 						orderBy={orderBy}
 						setOrder={setOrder}
 						setOrderBy={setOrderBy}
 						user={user}
 						profile={profile}
-						setCurrentJams={setCurrentJams}
+						// setCurrentJams={setCurrentJams}
 						songs={songs}
 						setSongs={setSongs}
 						showRatings={showRatings}
@@ -394,10 +355,10 @@ export default function App({
 					<DynamicAddVersion
 						songs={songs}
 						setSongs={setSongs}
-						jams={currentJams}
+						jams={jams}
 						user={user}
 						profile={profile}
-						setCurrentJams={setCurrentJams}
+						// setCurrentJams={setCurrentJams}
 						artist={artist}
 						setArtist={setArtist}
 						song={song}
@@ -428,18 +389,18 @@ export const getServerSideProps = async (ctx) => {
 		data: { session },
 	} = await supabase.auth.getSession();
 	const params = ctx.query;
+  console.log('params', params)
 	const artist = params?.artist;
 	const song = params?.song;
-  console.log('song in gSSP', song, typeof song)
 	const sounds = params?.sounds;
 	let tags = sounds?.split(',') ?? [];
-  console.log('tags in gSSP', tags)
 	const beforeDate = params?.beforeDate;
 	const afterDate = params?.afterDate;
 	const orderBy = params?.orderBy ?? 'id';
 	const asc = params?.order === 'asc' ? true : false;
 	const limit = params?.limit ?? 20;
-	const hasLink = params?.hasLink ?? false;
+  const showMoreFilters = params?.showMoreFilters === 'true';
+  const showListenable = params?.showListenable === 'true';
 	let jams = supabase.from('versions').select('*');
 	if (artist) {
 		jams = jams.eq('artist', artist);
@@ -460,15 +421,15 @@ export const getServerSideProps = async (ctx) => {
 			jams = jams.eq(tag, true);
 		});
 	}
+  if (showListenable) {
+    jams = jams.not('listen_link', 'is', null);
+  }
 	jams = jams.order(orderBy, { ascending: asc });
 	if (orderBy === 'avg_rating') {
 		jams = jams.order('num_ratings', { ascending: false });
 	}
 	if (orderBy === 'num_ratings') {
 		jams = jams.order('avg_rating', { ascending: false });
-	}
-	if (hasLink) {
-		jams = jams.neq('listen_link', null);
 	}
 	jams = jams.limit(limit);
 	const ideas = supabase
@@ -517,7 +478,8 @@ export const getServerSideProps = async (ctx) => {
 			initialOrderBy: orderBy,
 			initialOrder: asc ? 'asc' : 'desc',
 			initialLimit: limit,
-			initialHasLink: hasLink,
+			initialShowListenable: showListenable,
+      initialShowMoreFilters: showMoreFilters,
 		},
 	};
 };

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -92,7 +92,6 @@ export default function Welcome({ initialSession, initialUser }) {
 					console.error(err);
 				});
 		} else {
-			console.log('no user');
 			router.push('/join');
 		}
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx"
-  ],
+, "pages/welcome.js"  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
Changing filters or sort now creates a new url and navigates to it. Then getServerSideProps parses the url, queries db for the right jams and returns them. Same behavior as before (updating table) but with a unique url for every search

Also rearranged filters/simplified initial screen, added ability to change # of jams shown and only show jams with links